### PR TITLE
Implement ExePackage/CommandLine.

### DIFF
--- a/src/burn/engine/core.h
+++ b/src/burn/engine/core.h
@@ -47,6 +47,7 @@ const LPCWSTR BURN_BUNDLE_LAYOUT_DIRECTORY = L"WixBundleLayoutDirectory";
 const LPCWSTR BURN_BUNDLE_ACTION = L"WixBundleAction";
 const LPCWSTR BURN_BUNDLE_ACTIVE_PARENT = L"WixBundleActiveParent";
 const LPCWSTR BURN_BUNDLE_EXECUTE_PACKAGE_CACHE_FOLDER = L"WixBundleExecutePackageCacheFolder";
+const LPCWSTR BURN_BUNDLE_EXECUTE_PACKAGE_ACTION = L"WixBundleExecutePackageAction";
 const LPCWSTR BURN_BUNDLE_FORCED_RESTART_PACKAGE = L"WixBundleForcedRestartPackage";
 const LPCWSTR BURN_BUNDLE_INSTALLED = L"WixBundleInstalled";
 const LPCWSTR BURN_BUNDLE_ELEVATED = L"WixBundleElevated";

--- a/src/burn/engine/exeengine.cpp
+++ b/src/burn/engine/exeengine.cpp
@@ -569,8 +569,8 @@ extern "C" HRESULT ExeEngineExecutePackage(
         break;
 
     default:
-        hr = E_UNEXPECTED;
-        ExitOnFailure(hr, "Failed to get action arguments for executable package.");
+        hr = E_INVALIDARG;
+        ExitOnFailure1(hr, "Invalid Exe package action: %d.", pExecuteAction->exePackage.action);
     }
 
     // now add optional arguments
@@ -608,8 +608,8 @@ extern "C" HRESULT ExeEngineExecutePackage(
                 break;
 
             default:
-                hr = E_UNEXPECTED;
-                ExitOnFailure(hr, "Failed to get command-line arguments for executable package.");
+                hr = E_INVALIDARG;
+                ExitOnFailure1(hr, "Invalid Exe package action: %d.", pExecuteAction->exePackage.action);
             }
         }
     }
@@ -731,10 +731,8 @@ LExit:
     ReleaseHandle(pi.hThread);
     ReleaseHandle(pi.hProcess);
 
-    // TODO: Figure out if we care about "clearing" BURN_BUNDLE_EXECUTE_PACKAGE_ACTION (= 0)
-    // Best effort to clear the execute package cache folder and action variables.
+    // Best effort to clear the execute package cache folder variable.
     VariableSetString(pVariables, BURN_BUNDLE_EXECUTE_PACKAGE_CACHE_FOLDER, NULL, TRUE);
-    VariableSetNumeric(pVariables, BURN_BUNDLE_EXECUTE_PACKAGE_ACTION, BOOTSTRAPPER_ACTION_STATE_NONE, TRUE);
 
     return hr;
 }

--- a/src/burn/engine/exeengine.cpp
+++ b/src/burn/engine/exeengine.cpp
@@ -25,7 +25,7 @@ static HRESULT HandleExitCode(
 
 // function definitions
 
-extern "C" HRESULT ExeEngineParsePackageFromXml(
+static HRESULT ParseExitCodesFromXml(
     __in IXMLDOMNode* pixnExePackage,
     __in BURN_PACKAGE* pPackage
     )
@@ -34,6 +34,161 @@ extern "C" HRESULT ExeEngineParsePackageFromXml(
     IXMLDOMNodeList* pixnNodes = NULL;
     IXMLDOMNode* pixnNode = NULL;
     DWORD cNodes = 0;
+    LPWSTR scz = NULL;
+
+    // select exit code nodes
+    hr = XmlSelectNodes(pixnExePackage, L"ExitCode", &pixnNodes);
+    ExitOnFailure(hr, "Failed to select exit code nodes.");
+
+    // get exit code node count
+    hr = pixnNodes->get_length((long*) &cNodes);
+    ExitOnFailure(hr, "Failed to get exit code node count.");
+
+    if (cNodes)
+    {
+        // allocate memory for exit codes
+        pPackage->Exe.rgExitCodes = (BURN_EXE_EXIT_CODE*) MemAlloc(sizeof(BURN_EXE_EXIT_CODE) * cNodes, TRUE);
+        ExitOnNull(pPackage->Exe.rgExitCodes, hr, E_OUTOFMEMORY, "Failed to allocate memory for exit code structs.");
+
+        pPackage->Exe.cExitCodes = cNodes;
+
+        // parse package elements
+        for (DWORD i = 0; i < cNodes; ++i)
+        {
+            BURN_EXE_EXIT_CODE* pExitCode = &pPackage->Exe.rgExitCodes[i];
+
+            hr = XmlNextElement(pixnNodes, &pixnNode, NULL);
+            ExitOnFailure(hr, "Failed to get next node.");
+
+            // @Type
+            hr = XmlGetAttributeEx(pixnNode, L"Type", &scz);
+            ExitOnFailure(hr, "Failed to get @Type.");
+
+            if (CSTR_EQUAL == ::CompareStringW(LOCALE_INVARIANT, 0, scz, -1, L"success", -1))
+            {
+                pExitCode->type = BURN_EXE_EXIT_CODE_TYPE_SUCCESS;
+            }
+            else if (CSTR_EQUAL == ::CompareStringW(LOCALE_INVARIANT, 0, scz, -1, L"error", -1))
+            {
+                pExitCode->type = BURN_EXE_EXIT_CODE_TYPE_ERROR;
+            }
+            else if (CSTR_EQUAL == ::CompareStringW(LOCALE_INVARIANT, 0, scz, -1, L"scheduleReboot", -1))
+            {
+                pExitCode->type = BURN_EXE_EXIT_CODE_TYPE_SCHEDULE_REBOOT;
+            }
+            else if (CSTR_EQUAL == ::CompareStringW(LOCALE_INVARIANT, 0, scz, -1, L"forceReboot", -1))
+            {
+                pExitCode->type = BURN_EXE_EXIT_CODE_TYPE_FORCE_REBOOT;
+            }
+            else
+            {
+                hr = E_UNEXPECTED;
+                ExitOnFailure1(hr, "Invalid exit code type: %ls", scz);
+            }
+
+            // @Code
+            hr = XmlGetAttributeEx(pixnNode, L"Code", &scz);
+            ExitOnFailure(hr, "Failed to get @Code.");
+
+            if (L'*' == scz[0])
+            {
+                pExitCode->fWildcard = TRUE;
+            }
+            else
+            {
+                hr = StrStringToUInt32(scz, 0, (UINT*) &pExitCode->dwCode);
+                ExitOnFailure1(hr, "Failed to parse @Code value: %ls", scz);
+            }
+
+            // prepare next iteration
+            ReleaseNullObject(pixnNode);
+        }
+    }
+
+    hr = S_OK;
+
+LExit:
+    ReleaseObject(pixnNodes);
+    ReleaseObject(pixnNode);
+    ReleaseStr(scz);
+
+    return hr;
+}
+
+static HRESULT ParseCommandLineArgumentsFromXml(
+    __in IXMLDOMNode* pixnExePackage,
+    __in BURN_PACKAGE* pPackage
+    )
+{
+    HRESULT hr = S_OK;
+    IXMLDOMNodeList* pixnNodes = NULL;
+    IXMLDOMNode* pixnNode = NULL;
+    DWORD cNodes = 0;
+    LPWSTR scz = NULL;
+
+    // select exit code nodes
+    hr = XmlSelectNodes(pixnExePackage, L"CommandLine", &pixnNodes);
+    ExitOnFailure(hr, "Failed to select exit code nodes.");
+
+    // get exit code node count
+    hr = pixnNodes->get_length((long*) &cNodes);
+    ExitOnFailure(hr, "Failed to get exit code node count.");
+
+    if (cNodes)
+    {
+        // allocate memory for exit codes
+        pPackage->Exe.rgCommandLineArguments = (BURN_EXE_COMMAND_LINE_ARGUMENT*) MemAlloc(sizeof(BURN_EXE_COMMAND_LINE_ARGUMENT) * cNodes, TRUE);
+        ExitOnNull(pPackage->Exe.rgCommandLineArguments, hr, E_OUTOFMEMORY, "Failed to allocate memory for command-line argument structs.");
+
+        pPackage->Exe.cCommandLineArguments = cNodes;
+
+        // parse package elements
+        for (DWORD i = 0; i < cNodes; ++i)
+        {
+            BURN_EXE_COMMAND_LINE_ARGUMENT* pCommandLineArgument = &pPackage->Exe.rgCommandLineArguments[i];
+
+            hr = XmlNextElement(pixnNodes, &pixnNode, NULL);
+            ExitOnFailure(hr, "Failed to get next command-line argument node.");
+
+            // @InstallArgument
+            hr = XmlGetAttributeEx(pixnNode, L"InstallArgument", &pCommandLineArgument->sczInstallArgument);
+            ExitOnFailure(hr, "Failed to get @InstallArgument.");
+
+            // @UninstallArgument
+            hr = XmlGetAttributeEx(pixnNode, L"UninstallArgument", &pCommandLineArgument->sczUninstallArgument);
+            ExitOnFailure(hr, "Failed to get @UninstallArgument.");
+
+            // @RepairArgument
+            hr = XmlGetAttributeEx(pixnNode, L"RepairArgument", &pCommandLineArgument->sczRepairArgument);
+            ExitOnFailure(hr, "Failed to get @RepairArgument.");
+
+            // @Condition
+            hr = XmlGetAttributeEx(pixnNode, L"Condition", &pCommandLineArgument->sczCondition);
+            ExitOnFailure(hr, "Failed to get @Condition.");
+
+            // prepare next iteration
+            ReleaseNullObject(pixnNode);
+        }
+    }
+
+    hr = S_OK;
+
+LExit:
+    ReleaseObject(pixnNodes);
+    ReleaseObject(pixnNode);
+    ReleaseStr(scz);
+
+    return hr;
+}
+
+extern "C" HRESULT ExeEngineParsePackageFromXml(
+    __in IXMLDOMNode* pixnExePackage,
+    __in BURN_PACKAGE* pPackage
+    )
+{
+    HRESULT hr = S_OK;
+    IXMLDOMNodeList* pixnNodes = NULL;
+    IXMLDOMNode* pixnNode = NULL;
     LPWSTR scz = NULL;
 
     // @DetectCondition
@@ -86,76 +241,11 @@ extern "C" HRESULT ExeEngineParsePackageFromXml(
         ExitOnFailure(hr, "Failed to get @Protocol.");
     }
 
-    // select exit code nodes
-    hr = XmlSelectNodes(pixnExePackage, L"ExitCode", &pixnNodes);
-    ExitOnFailure(hr, "Failed to select exit code nodes.");
+    hr = ParseExitCodesFromXml(pixnExePackage, pPackage);
+    ExitOnFailure(hr, "Failed to parse exit codes.");
 
-    // get exit code node count
-    hr = pixnNodes->get_length((long*)&cNodes);
-    ExitOnFailure(hr, "Failed to get exit code node count.");
-
-    if (cNodes)
-    {
-        // allocate memory for exit codes
-        pPackage->Exe.rgExitCodes = (BURN_EXE_EXIT_CODE*)MemAlloc(sizeof(BURN_EXE_EXIT_CODE) * cNodes, TRUE);
-        ExitOnNull(pPackage->Exe.rgExitCodes, hr, E_OUTOFMEMORY, "Failed to allocate memory for exit code structs.");
-
-        pPackage->Exe.cExitCodes = cNodes;
-
-        // parse package elements
-        for (DWORD i = 0; i < cNodes; ++i)
-        {
-            BURN_EXE_EXIT_CODE* pExitCode = &pPackage->Exe.rgExitCodes[i];
-
-            hr = XmlNextElement(pixnNodes, &pixnNode, NULL);
-            ExitOnFailure(hr, "Failed to get next node.");
-
-            // @Type
-            hr = XmlGetAttributeEx(pixnNode, L"Type", &scz);
-            ExitOnFailure(hr, "Failed to get @Type.");
-
-            if (CSTR_EQUAL == ::CompareStringW(LOCALE_INVARIANT, 0, scz, -1, L"success", -1))
-            {
-                pExitCode->type = BURN_EXE_EXIT_CODE_TYPE_SUCCESS;
-            }
-            else if (CSTR_EQUAL == ::CompareStringW(LOCALE_INVARIANT, 0, scz, -1, L"error", -1))
-            {
-                pExitCode->type = BURN_EXE_EXIT_CODE_TYPE_ERROR;
-            }
-            else if (CSTR_EQUAL == ::CompareStringW(LOCALE_INVARIANT, 0, scz, -1, L"scheduleReboot", -1))
-            {
-                pExitCode->type = BURN_EXE_EXIT_CODE_TYPE_SCHEDULE_REBOOT;
-            }
-            else if (CSTR_EQUAL == ::CompareStringW(LOCALE_INVARIANT, 0, scz, -1, L"forceReboot", -1))
-            {
-                pExitCode->type = BURN_EXE_EXIT_CODE_TYPE_FORCE_REBOOT;
-            }
-            else
-            {
-                hr = E_UNEXPECTED;
-                ExitOnFailure1(hr, "Invalid exit code type: %ls", scz);
-            }
-
-            // @Code
-            hr = XmlGetAttributeEx(pixnNode, L"Code", &scz);
-            ExitOnFailure(hr, "Failed to get @Code.");
-
-            if (L'*' == scz[0])
-            {
-                pExitCode->fWildcard = TRUE;
-            }
-            else
-            {
-                hr = StrStringToUInt32(scz, 0, (UINT*)&pExitCode->dwCode);
-                ExitOnFailure1(hr, "Failed to parse @Code value: %ls", scz);
-            }
-
-            // prepare next iteration
-            ReleaseNullObject(pixnNode);
-        }
-    }
-
-    hr = S_OK;
+    hr = ParseCommandLineArgumentsFromXml(pixnExePackage, pPackage);
+    ExitOnFailure(hr, "Failed to parse command lines.");
 
 LExit:
     ReleaseObject(pixnNodes);
@@ -177,6 +267,20 @@ extern "C" void ExeEnginePackageUninitialize(
     ReleaseStr(pPackage->Exe.sczAncestors);
     //ReleaseStr(pPackage->Exe.sczProgressSwitch);
     ReleaseMem(pPackage->Exe.rgExitCodes);
+
+    // free command-line arguments
+    if (pPackage->Exe.rgCommandLineArguments)
+    {
+        for (DWORD i = 0; i < pPackage->Exe.cCommandLineArguments; ++i)
+        {
+            BURN_EXE_COMMAND_LINE_ARGUMENT* pCommandLineArgument = &pPackage->Exe.rgCommandLineArguments[i];
+            ReleaseStr(pCommandLineArgument->sczInstallArgument);
+            ReleaseStr(pCommandLineArgument->sczUninstallArgument);
+            ReleaseStr(pCommandLineArgument->sczRepairArgument);
+            ReleaseStr(pCommandLineArgument->sczCondition);
+        }
+        MemFree(pPackage->Exe.rgCommandLineArguments);
+    }
 
     // clear struct
     memset(&pPackage->Exe, 0, sizeof(pPackage->Exe));
@@ -426,6 +530,7 @@ extern "C" HRESULT ExeEngineExecutePackage(
     BOOL fChangedCurrentDirectory = FALSE;
     int nResult = IDNOACTION;
     LPCWSTR wzArguments = NULL;
+    LPWSTR sczArguments = NULL;
     LPWSTR sczArgumentsFormatted = NULL;
     LPWSTR sczArgumentsObfuscated = NULL;
     LPWSTR sczCachedDirectory = NULL;
@@ -441,8 +546,9 @@ extern "C" HRESULT ExeEngineExecutePackage(
     hr = CacheGetCompletedPath(pExecuteAction->exePackage.pPackage->fPerMachine, pExecuteAction->exePackage.pPackage->sczCacheId, &sczCachedDirectory);
     ExitOnFailure1(hr, "Failed to get cached path for package: %ls", pExecuteAction->exePackage.pPackage->sczId);
 
-    // Best effort to set the execute package cache folder variable.
+    // Best effort to set the execute package cache folder and action variables.
     VariableSetString(pVariables, BURN_BUNDLE_EXECUTE_PACKAGE_CACHE_FOLDER, sczCachedDirectory, TRUE);
+    VariableSetNumeric(pVariables, BURN_BUNDLE_EXECUTE_PACKAGE_ACTION, pExecuteAction->exePackage.action, TRUE);
 
     hr = PathConcat(sczCachedDirectory, pExecuteAction->exePackage.pPackage->rgPayloads[0].pPayload->sczFilePath, &sczExecutablePath);
     ExitOnFailure(hr, "Failed to build executable path.");
@@ -467,16 +573,57 @@ extern "C" HRESULT ExeEngineExecutePackage(
         ExitOnFailure(hr, "Failed to get action arguments for executable package.");
     }
 
-    // build command
-    if (wzArguments && *wzArguments)
+    // now add optional arguments
+    hr = StrAllocString(&sczArguments, wzArguments && *wzArguments ? wzArguments : L"", 0);
+    ExitOnFailure(hr, "Failed to copy package arguments.");
+
+    for (DWORD i = 0; i < pExecuteAction->exePackage.pPackage->Exe.cCommandLineArguments; ++i)
     {
-        hr = VariableFormatString(pVariables, wzArguments, &sczArgumentsFormatted, NULL);
+        BURN_EXE_COMMAND_LINE_ARGUMENT* commandLineArgument = &pExecuteAction->exePackage.pPackage->Exe.rgCommandLineArguments[i];
+        BOOL fCondition = FALSE;
+
+        hr = ConditionEvaluate(pVariables, commandLineArgument->sczCondition, &fCondition);
+        ExitOnFailure(hr, "Failed to evaluate executable package command-line condition.");
+
+        if (fCondition)
+        {
+            hr = StrAllocConcat(&sczArguments, L" ", 0);
+            ExitOnFailure(hr, "Failed to separate command-line arguments.");
+
+            switch (pExecuteAction->exePackage.action)
+            {
+            case BOOTSTRAPPER_ACTION_STATE_INSTALL:
+                hr = StrAllocConcat(&sczArguments, commandLineArgument->sczInstallArgument, 0);
+                ExitOnFailure(hr, "Failed to get command-line argument for install.");
+                break;
+
+            case BOOTSTRAPPER_ACTION_STATE_UNINSTALL:
+                hr = StrAllocConcat(&sczArguments, commandLineArgument->sczUninstallArgument, 0);
+                ExitOnFailure(hr, "Failed to get command-line argument for uninstall.");
+                break;
+
+            case BOOTSTRAPPER_ACTION_STATE_REPAIR:
+                hr = StrAllocConcat(&sczArguments, commandLineArgument->sczRepairArgument, 0);
+                ExitOnFailure(hr, "Failed to get command-line argument for repair.");
+                break;
+
+            default:
+                hr = E_UNEXPECTED;
+                ExitOnFailure(hr, "Failed to get command-line arguments for executable package.");
+            }
+        }
+    }
+
+    // build command
+    if (0 < lstrlenW(sczArguments))
+    {
+        hr = VariableFormatString(pVariables, sczArguments, &sczArgumentsFormatted, NULL);
         ExitOnFailure(hr, "Failed to format argument string.");
 
         hr = StrAllocFormattedSecure(&sczCommand, L"\"%ls\" %s", sczExecutablePath, sczArgumentsFormatted);
         ExitOnFailure(hr, "Failed to create executable command.");
 
-        hr = VariableFormatStringObfuscated(pVariables, wzArguments, &sczArgumentsObfuscated, NULL);
+        hr = VariableFormatStringObfuscated(pVariables, sczArguments, &sczArgumentsObfuscated, NULL);
         ExitOnFailure(hr, "Failed to format obfuscated argument string.");
 
         hr = StrAllocFormatted(&sczCommandObfuscated, L"\"%ls\" %s", sczExecutablePath, sczArgumentsObfuscated);
@@ -573,6 +720,7 @@ LExit:
         ::SetCurrentDirectoryW(wzCurrentDirectory);
     }
 
+    StrSecureZeroFreeString(sczArguments);
     StrSecureZeroFreeString(sczArgumentsFormatted);
     ReleaseStr(sczArgumentsObfuscated);
     ReleaseStr(sczCachedDirectory);
@@ -583,8 +731,10 @@ LExit:
     ReleaseHandle(pi.hThread);
     ReleaseHandle(pi.hProcess);
 
-    // Best effort to clear the execute package cache folder variable.
+    // TODO: Figure out if we care about "clearing" BURN_BUNDLE_EXECUTE_PACKAGE_ACTION (= 0)
+    // Best effort to clear the execute package cache folder and action variables.
     VariableSetString(pVariables, BURN_BUNDLE_EXECUTE_PACKAGE_CACHE_FOLDER, NULL, TRUE);
+    VariableSetNumeric(pVariables, BURN_BUNDLE_EXECUTE_PACKAGE_ACTION, BOOTSTRAPPER_ACTION_STATE_NONE, TRUE);
 
     return hr;
 }

--- a/src/burn/engine/exeengine.cpp
+++ b/src/burn/engine/exeengine.cpp
@@ -731,8 +731,9 @@ LExit:
     ReleaseHandle(pi.hThread);
     ReleaseHandle(pi.hProcess);
 
-    // Best effort to clear the execute package cache folder variable.
+    // Best effort to clear the execute package cache folder and action variables.
     VariableSetString(pVariables, BURN_BUNDLE_EXECUTE_PACKAGE_CACHE_FOLDER, NULL, TRUE);
+    VariableSetString(pVariables, BURN_BUNDLE_EXECUTE_PACKAGE_ACTION, NULL, TRUE);
 
     return hr;
 }

--- a/src/burn/engine/msiengine.cpp
+++ b/src/burn/engine/msiengine.cpp
@@ -1265,9 +1265,8 @@ LExit:
             break;
     }
 
-    // Best effort to clear the execute package cache folder and action variables.
+    // Best effort to clear the execute package cache folder variable.
     VariableSetString(pVariables, BURN_BUNDLE_EXECUTE_PACKAGE_CACHE_FOLDER, NULL, TRUE);
-    VariableSetNumeric(pVariables, BURN_BUNDLE_EXECUTE_PACKAGE_ACTION, BOOTSTRAPPER_ACTION_STATE_NONE, TRUE);
 
     return hr;
 }

--- a/src/burn/engine/msiengine.cpp
+++ b/src/burn/engine/msiengine.cpp
@@ -1129,6 +1129,9 @@ extern "C" HRESULT MsiEngineExecutePackage(
         ExitOnFailure(hr, "Failed to build MSI path.");
     }
 
+    // Best effort to set the execute package action variable.
+    VariableSetNumeric(pVariables, BURN_BUNDLE_EXECUTE_PACKAGE_ACTION, pExecuteAction->msiPackage.action, TRUE);
+    
     // Wire up the external UI handler and logging.
     hr = WiuInitializeExternalUI(pfnMessageHandler, pExecuteAction->msiPackage.uiLevel, hwndParent, pvContext, fRollback, &context);
     ExitOnFailure(hr, "Failed to initialize external UI handler.");
@@ -1262,8 +1265,9 @@ LExit:
             break;
     }
 
-    // Best effort to clear the execute package cache folder variable.
+    // Best effort to clear the execute package cache folder and action variables.
     VariableSetString(pVariables, BURN_BUNDLE_EXECUTE_PACKAGE_CACHE_FOLDER, NULL, TRUE);
+    VariableSetNumeric(pVariables, BURN_BUNDLE_EXECUTE_PACKAGE_ACTION, BOOTSTRAPPER_ACTION_STATE_NONE, TRUE);
 
     return hr;
 }

--- a/src/burn/engine/msiengine.cpp
+++ b/src/burn/engine/msiengine.cpp
@@ -1265,8 +1265,9 @@ LExit:
             break;
     }
 
-    // Best effort to clear the execute package cache folder variable.
+    // Best effort to clear the execute package cache folder and action variables.
     VariableSetString(pVariables, BURN_BUNDLE_EXECUTE_PACKAGE_CACHE_FOLDER, NULL, TRUE);
+    VariableSetString(pVariables, BURN_BUNDLE_EXECUTE_PACKAGE_ACTION, NULL, TRUE);
 
     return hr;
 }

--- a/src/burn/engine/mspengine.cpp
+++ b/src/burn/engine/mspengine.cpp
@@ -599,9 +599,8 @@ LExit:
             break;
     }
 
-    // Best effort to clear the execute package cache folder and action variables.
+    // Best effort to clear the execute package cache folder variable.
     VariableSetString(pVariables, BURN_BUNDLE_EXECUTE_PACKAGE_CACHE_FOLDER, NULL, TRUE);
-    VariableSetNumeric(pVariables, BURN_BUNDLE_EXECUTE_PACKAGE_ACTION, BOOTSTRAPPER_ACTION_STATE_NONE, TRUE);
 
     return hr;
 }

--- a/src/burn/engine/mspengine.cpp
+++ b/src/burn/engine/mspengine.cpp
@@ -599,8 +599,9 @@ LExit:
             break;
     }
 
-    // Best effort to clear the execute package cache folder variable.
+    // Best effort to clear the execute package cache folder and action variables.
     VariableSetString(pVariables, BURN_BUNDLE_EXECUTE_PACKAGE_CACHE_FOLDER, NULL, TRUE);
+    VariableSetString(pVariables, BURN_BUNDLE_EXECUTE_PACKAGE_ACTION, NULL, TRUE);
 
     return hr;
 }

--- a/src/burn/engine/mspengine.cpp
+++ b/src/burn/engine/mspengine.cpp
@@ -491,6 +491,7 @@ extern "C" HRESULT MspEngineExecutePackage(
             hr = CacheGetCompletedPath(pMspPackage->fPerMachine, pMspPackage->sczCacheId, &sczCachedDirectory);
             ExitOnFailure1(hr, "Failed to get cached path for MSP package: %ls", pMspPackage->sczId);
 
+            // TODO: Figure out if this makes sense -- the variable is set to the last patch's path only
             // Best effort to set the execute package cache folder variable.
             VariableSetString(pVariables, BURN_BUNDLE_EXECUTE_PACKAGE_CACHE_FOLDER, sczCachedDirectory, TRUE);
 
@@ -513,6 +514,9 @@ extern "C" HRESULT MspEngineExecutePackage(
         hr = StrAllocConcat(&sczPatches, wzAppend, 0);
         ExitOnFailure(hr, "Failed to append patch.");
     }
+
+    // Best effort to set the execute package action variable.
+    VariableSetNumeric(pVariables, BURN_BUNDLE_EXECUTE_PACKAGE_ACTION, pExecuteAction->mspTarget.action, TRUE);
 
     // Wire up the external UI handler and logging.
     hr = WiuInitializeExternalUI(pfnMessageHandler, uiLevel, hwndParent, pvContext, fRollback, &context);
@@ -595,8 +599,9 @@ LExit:
             break;
     }
 
-    // Best effort to clear the execute package cache folder variable.
+    // Best effort to clear the execute package cache folder and action variables.
     VariableSetString(pVariables, BURN_BUNDLE_EXECUTE_PACKAGE_CACHE_FOLDER, NULL, TRUE);
+    VariableSetNumeric(pVariables, BURN_BUNDLE_EXECUTE_PACKAGE_ACTION, BOOTSTRAPPER_ACTION_STATE_NONE, TRUE);
 
     return hr;
 }

--- a/src/burn/engine/package.h
+++ b/src/burn/engine/package.h
@@ -88,6 +88,14 @@ typedef struct _BURN_EXE_EXIT_CODE
     BOOL fWildcard;
 } BURN_EXE_EXIT_CODE;
 
+typedef struct _BURN_EXE_COMMAND_LINE_ARGUMENT
+{
+    LPWSTR sczInstallArgument;
+    LPWSTR sczUninstallArgument;
+    LPWSTR sczRepairArgument;
+    LPWSTR sczCondition;
+} BURN_EXE_COMMAND_LINE_ARGUMENT;
+
 typedef struct _BURN_MSPTARGETPRODUCT
 {
     MSIINSTALLCONTEXT context;
@@ -228,6 +236,9 @@ typedef struct _BURN_PACKAGE
 
             BURN_EXE_EXIT_CODE* rgExitCodes;
             DWORD cExitCodes;
+
+            BURN_EXE_COMMAND_LINE_ARGUMENT* rgCommandLineArguments;
+            DWORD cCommandLineArguments;
         } Exe;
         struct
         {

--- a/src/burn/engine/variable.cpp
+++ b/src/burn/engine/variable.cpp
@@ -266,6 +266,7 @@ extern "C" HRESULT VariableInitialize(
         {L"WindowsVolume", InitializeVariableWindowsVolumeFolder, 0},
         {BURN_BUNDLE_ACTION, InitializeVariableNumeric, 0},
         {BURN_BUNDLE_EXECUTE_PACKAGE_CACHE_FOLDER, InitializeVariableString, NULL},
+        {BURN_BUNDLE_EXECUTE_PACKAGE_ACTION, InitializeVariableNumeric, 0},
         {BURN_BUNDLE_FORCED_RESTART_PACKAGE, InitializeVariableString, NULL, TRUE},
         {BURN_BUNDLE_INSTALLED, InitializeVariableNumeric, 0},
         {BURN_BUNDLE_ELEVATED, InitializeVariableNumeric, 0},

--- a/src/tools/wix/Binder.cs
+++ b/src/tools/wix/Binder.cs
@@ -3684,6 +3684,26 @@ namespace Microsoft.Tools.WindowsInstallerXml
                 }
             }
 
+            // Load the CommandLine information...
+            Table commandLineTable = bundle.Tables["WixCommandLine"];
+            if (null != commandLineTable && 0 < commandLineTable.Rows.Count)
+            {
+                foreach (Row row in commandLineTable.Rows)
+                {
+                    CommandLineInfo commandLine = new CommandLineInfo(row);
+
+                    ChainPackageInfo package;
+                    if (allPackages.TryGetValue(commandLine.PackageId, out package))
+                    {
+                        package.CommandLines.Add(commandLine);
+                    }
+                    else
+                    {
+                        core.OnMessage(WixErrors.IdentifierNotFound("Package", commandLine.PackageId));
+                    }
+                }
+            }
+
             // Resolve any delayed fields before generating the manifest.
             if (0 < delayedFields.Count)
             {
@@ -4548,6 +4568,16 @@ namespace Microsoft.Tools.WindowsInstallerXml
                         writer.WriteStartElement("ExitCode");
                         writer.WriteAttributeString("Type", exitCode.Type);
                         writer.WriteAttributeString("Code", exitCode.Code);
+                        writer.WriteEndElement();
+                    }
+
+                    foreach (CommandLineInfo commandLine in package.CommandLines)
+                    {
+                        writer.WriteStartElement("CommandLine");
+                        writer.WriteAttributeString("InstallArgument", commandLine.InstallArgument);
+                        writer.WriteAttributeString("UninstallArgument", commandLine.UninstallArgument);
+                        writer.WriteAttributeString("RepairArgument", commandLine.RepairArgument);
+                        writer.WriteAttributeString("Condition", commandLine.Condition);
                         writer.WriteEndElement();
                     }
 

--- a/src/tools/wix/ChainPackageInfo.cs
+++ b/src/tools/wix/ChainPackageInfo.cs
@@ -170,6 +170,7 @@ namespace Microsoft.Tools.WindowsInstallerXml
             this.MsiProperties = new List<MsiPropertyInfo>();
             this.SlipstreamMsps = new List<string>();
             this.ExitCodes = new List<ExitCodeInfo>();
+            this.CommandLines = new List<CommandLineInfo>();
             this.Provides = new ProvidesDependencyCollection();
             this.TargetCodes = new RowDictionary<WixBundlePatchTargetCodeRow>();
 
@@ -569,6 +570,7 @@ namespace Microsoft.Tools.WindowsInstallerXml
         public List<MsiPropertyInfo> MsiProperties { get; private set; }
         public List<string> SlipstreamMsps { get; private set; }
         public List<ExitCodeInfo> ExitCodes { get; private set; }
+        public List<CommandLineInfo> CommandLines { get; private set; }
         public ProvidesDependencyCollection Provides { get; private set; }
         public RowDictionary<WixBundlePatchTargetCodeRow> TargetCodes { get; private set; }
         public bool TargetUnspecified { get; private set; }

--- a/src/tools/wix/CommandLineInfo.cs
+++ b/src/tools/wix/CommandLineInfo.cs
@@ -1,0 +1,43 @@
+﻿//-------------------------------------------------------------------------------------------------
+// <copyright file="CommandLineInfo.cs" company="Outercurve Foundation">
+//   Copyright (c) 2004, Outercurve Foundation.
+//   This software is released under Microsoft Reciprocal License (MS-RL).
+//   The license and further copyright text can be found in the file
+//   LICENSE.TXT at the root directory of the distribution.
+// </copyright>
+// 
+// <summary>
+// Utility class for Burn ExePackage CommandLine information.
+// </summary>
+//-------------------------------------------------------------------------------------------------
+
+namespace Microsoft.Tools.WindowsInstallerXml
+{
+    using System;
+
+    /// <summary>
+    /// Utility class for Burn CommandLine information.
+    /// </summary>
+    internal class CommandLineInfo
+    {
+        public CommandLineInfo(Row row)
+            : this((string)row[0], (string)row[1], (string)row[2], (string)row[3], (string)row[4])
+        {
+        }
+
+        public CommandLineInfo(string packageId, string installCommand, string uninstallCommand, string repairCommand, string condition)
+        {
+            this.PackageId = packageId;
+            this.InstallArgument = installCommand;
+            this.UninstallArgument = uninstallCommand;
+            this.RepairArgument = repairCommand;
+            this.Condition = condition;
+        }
+
+        public string PackageId { get; private set; }
+        public string InstallArgument { get; private set; }
+        public string UninstallArgument { get; private set; }
+        public string RepairArgument { get; private set; }
+        public string Condition { get; private set; }
+    }
+}

--- a/src/tools/wix/Compiler.cs
+++ b/src/tools/wix/Compiler.cs
@@ -21099,7 +21099,7 @@ namespace Microsoft.Tools.WindowsInstallerXml
                             behavior = this.core.GetAttributeValue(sourceLineNumbers, attrib);
                             break;
                         default:
-                            // hygene: throw an exception if there are any unknown attributes
+                            // hygiene: throw an exception if there are any unknown attributes
                             this.core.UnexpectedAttribute(sourceLineNumbers, attrib);
                             break;
                     }
@@ -21115,7 +21115,7 @@ namespace Microsoft.Tools.WindowsInstallerXml
                 this.core.OnMessage(WixErrors.ExpectedAttribute(sourceLineNumbers, node.Name, "Behavior"));
             }
 
-            // hygene: throw an exception if there are any subelements
+            // hygiene: throw an exception if there are any subelements
             foreach (XmlNode child in node.ChildNodes)
             {
                 if (XmlNodeType.Element == child.NodeType)
@@ -21776,6 +21776,13 @@ namespace Microsoft.Tools.WindowsInstallerXml
                                     this.ParseExitCodeElement(child, id);
                                 }
                                 break;
+                            case "CommandLine":
+                                allowed = (packageType == ChainPackageType.Exe);
+                                if (allowed)
+                                {
+                                    this.ParseCommandLineElement(child, id);
+                                }
+                                break;
                             case "RemotePayload":
                                 // Handled previously
                                 break;
@@ -21896,6 +21903,81 @@ namespace Microsoft.Tools.WindowsInstallerXml
                 this.CreateChainPackageMetaRows(sourceLineNumbers, parentType, parentId, ComplexReferenceChildType.Package, id, previousType, previousId, after);
             }
             return id;
+        }
+
+        /// <summary>
+        /// Parse CommandLine element.
+        /// </summary>
+        /// <param name="node">Element to parse</param>
+        private void ParseCommandLineElement(XmlNode node, string packageId)
+        {
+            SourceLineNumberCollection sourceLineNumbers = Preprocessor.GetSourceLineNumbers(node);
+            string installArgument = null;
+            string uninstallArgument = null;
+            string repairArgument = null;
+            string condition = null;
+
+            foreach (XmlAttribute attrib in node.Attributes)
+            {
+                if (0 == attrib.NamespaceURI.Length || attrib.NamespaceURI == this.schema.TargetNamespace)
+                {
+                    switch (attrib.LocalName)
+                    {
+                        case "InstallArgument":
+                            installArgument = this.core.GetAttributeValue(sourceLineNumbers, attrib);
+                            break;
+                        case "UninstallArgument":
+                            uninstallArgument = this.core.GetAttributeValue(sourceLineNumbers, attrib);
+                            break;
+                        case "RepairArgument":
+                            repairArgument = this.core.GetAttributeValue(sourceLineNumbers, attrib);
+                            break;
+                        case "Condition":
+                            condition = this.core.GetAttributeValue(sourceLineNumbers, attrib);
+                            break;
+                        default:
+                            // hygiene: throw an exception if there are any unknown attributes
+                            this.core.UnexpectedAttribute(sourceLineNumbers, attrib);
+                            break;
+                    }
+                }
+                else
+                {
+                    this.core.UnsupportedExtensionAttribute(sourceLineNumbers, attrib);
+                }
+            }
+
+            // TODO: Consider whether we want to support conditionless
+            if (String.IsNullOrEmpty(condition))
+            {
+                this.core.OnMessage(WixErrors.ExpectedAttribute(sourceLineNumbers, node.Name, "Condition"));
+            }
+
+            // hygiene: throw an exception if there are any subelements
+            foreach (XmlNode child in node.ChildNodes)
+            {
+                if (XmlNodeType.Element == child.NodeType)
+                {
+                    if (child.NamespaceURI == this.schema.TargetNamespace)
+                    {
+                        this.core.UnexpectedElement(node, child);
+                    }
+                    else
+                    {
+                        this.core.UnsupportedExtensionElement(node, child);
+                    }
+                }
+            }
+
+            if (!this.core.EncounteredError)
+            {
+                Row row = this.core.CreateRow(sourceLineNumbers, "WixCommandLine");
+                row[0] = packageId;
+                row[1] = installArgument;
+                row[2] = uninstallArgument;
+                row[3] = repairArgument;
+                row[4] = condition;
+            }
         }
 
         /// <summary>

--- a/src/tools/wix/Data/tables.xml
+++ b/src/tools/wix/Data/tables.xml
@@ -1790,6 +1790,14 @@
         <columnDefinition name="ChainPackage_Msp" type="string" length="0" category="identifier" primaryKey="yes"
                 keyTable="ChainPackage" keyColumn="1" description="Reference to a ChainPackage entry in the ChainPackage table for the referenced Msp." />
     </tableDefinition>
+    <tableDefinition name="WixCommandLine" unreal="yes">
+        <columnDefinition name="ChainPackage_" type="string" length="0" category="identifier" 
+                keyTable="ChainPackage" keyColumn="1" description="Reference to a ChainPackage entry in the ChainPackage table."/>
+        <columnDefinition name="InstallArgument" type="string" length="0" nullable="yes" />
+        <columnDefinition name="UninstallArgument" type="string" length="0" nullable="yes" />
+        <columnDefinition name="RepairArgument" type="string" length="0" nullable="yes" />
+        <columnDefinition name="Condition" type="string" length="0" nullable="yes" />
+    </tableDefinition>
     <tableDefinition name="RelatedBundle" unreal="yes">
         <columnDefinition name="Id" type="string" length="38" category="guid" primaryKey="yes" />
         <columnDefinition name="Action" type="number" length="4" />

--- a/src/tools/wix/Wix.csproj
+++ b/src/tools/wix/Wix.csproj
@@ -48,6 +48,7 @@
     <Compile Include="ColumnDefinition.cs" />
     <Compile Include="ColumnDefinitionCollection.cs" />
     <Compile Include="CommandLine.cs" />
+    <Compile Include="CommandLineInfo.cs" />
     <Compile Include="Common.cs" />
     <Compile Include="Compiler.cs" />
     <Compile Include="CompilerCore.cs" />
@@ -272,12 +273,10 @@
     <Reference Include="System.Windows.Forms" />
     <Reference Include="System.Xml" />
   </ItemGroup>
-  
   <ItemGroup>
     <ProjectReference Include="..\..\dtf\Libraries\Resources\Resources.csproj" />
     <ProjectReference Include="..\..\dtf\Libraries\WindowsInstaller\WindowsInstaller.csproj" />
     <ProjectReference Include="..\winterop\winterop.vcxproj" />
   </ItemGroup>
-  
   <Import Project="$([MSBuild]::GetDirectoryNameOfFileAbove($(MSBuildProjectDirectory), wix.proj))\tools\WixBuild.targets" />
 </Project>

--- a/src/tools/wix/Xsd/wix.xsd
+++ b/src/tools/wix/Xsd/wix.xsd
@@ -760,6 +760,7 @@
         <xs:element ref="PayloadGroupRef" />
         <xs:element ref="RemotePayload" />
         <xs:element ref="ExitCode" />
+        <xs:element ref="CommandLine" />
         <xs:any namespace="##other" processContents="lax">
           <xs:annotation>
             <xs:documentation>
@@ -1229,6 +1230,43 @@
             <xs:enumeration value="forceReboot" />
           </xs:restriction>
         </xs:simpleType>
+      </xs:attribute>
+    </xs:complexType>
+  </xs:element>
+  <xs:element name="CommandLine">
+    <xs:annotation>
+      <xs:documentation>Describes additional, conditional command-line arguments for an ExePackage.</xs:documentation>
+      <xs:appinfo>
+        <xse:parent namespace="http://schemas.microsoft.com/wix/2006/wi" ref="ExePackage" />
+      </xs:appinfo>
+    </xs:annotation>
+    <xs:complexType>
+      <xs:attribute name="InstallArgument" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>Additional command-line arguments to apply during package installation if Condition is true.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="UninstallArgument" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>Additional command-line arguments to apply during package uninstallation if Condition is true.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="RepairArgument" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>Additional command-line arguments to apply during package repair if Condition is true.</xs:documentation>
+        </xs:annotation>
+      </xs:attribute>
+      <xs:attribute name="Condition" type="xs:string">
+        <xs:annotation>
+          <xs:documentation>
+              The condition that controls whether the command-line arguments specified in the
+              InstallArgument, UninstallArgument, or RepairArgument attributes are appended to the
+              command line passed to the ExePackage. Which attribute is used depends on the
+              action being applied to the ExePackage. For example, when the ExePackage is
+              being installed, the InstallArgument attribute value is appended to the command
+              line when the ExePackage is executed.
+          </xs:documentation>
+        </xs:annotation>
       </xs:attribute>
     </xs:complexType>
   </xs:element>


### PR DESCRIPTION
- Add WixBundleExecutePackageAction variable: Set to the BOOTSTRAPPER_ACTION_STATE of the package as it's about to executed.
- Add ExePackage/CommandLine to compiler and binder.
- Update Burn to parse CommandLine table in manifest and apply it during ExePackage execution.
