### PR TITLE
Allow FontId as a legal attribute on the Combobox control schema

### DIFF
--- a/src/libs/dutil/xsd/thmutil.xsd
+++ b/src/libs/dutil/xsd/thmutil.xsd
@@ -279,9 +279,14 @@
                 <xse:parent namespace="http://wixtoolset.org/schemas/thmutil/2010" ref="Theme" />
             </xs:appinfo>
         </xs:annotation>
-      <xs:complexType>
-        <xs:attributeGroup ref="CommonControlAttributes" />
-      </xs:complexType>
+        <xs:complexType>
+            <xs:attributeGroup ref="CommonControlAttributes" />
+            <xs:attribute name="FontId" type="xs:nonNegativeInteger" use="required">
+                <xs:annotation>
+                    <xs:documentation>Numeric identifier to the Font element that serves as the font for the control.</xs:documentation>
+                </xs:annotation>
+             </xs:attribute>
+        </xs:complexType>
     </xs:element>
 
     <xs:element name="Editbox">


### PR DESCRIPTION
It was already reading the attribute, just the schema was falsely claiming that it wasn't supported.
