### PR TITLE
Add IBootstrapperEngine::SetUpdateSource

### DIFF
--- a/src/burn/engine/EngineForApplication.cpp
+++ b/src/burn/engine/EngineForApplication.cpp
@@ -716,7 +716,7 @@ public: // IBootstrapperEngine
         __in_z LPCWSTR wzApprovedExeForElevationId,
         __in_z_opt LPCWSTR wzArguments,
         __in DWORD dwWaitForInputIdleTimeout
-        )
+    )
     {
         HRESULT hr = S_OK;
         BURN_APPROVED_EXE* pApprovedExe = NULL;
@@ -767,6 +767,34 @@ public: // IBootstrapperEngine
         {
             ApprovedExesUninitializeLaunch(pLaunchApprovedExe);
         }
+
+        return hr;
+    }
+
+    virtual STDMETHODIMP SetUpdateSource(
+        __in_z LPCWSTR wzUrl,
+        __in_z_opt LPWSTR /*wzUser*/,
+        __in_z_opt LPWSTR /*wzPassword*/
+    )
+    {
+        HRESULT hr = S_OK;
+
+        ::EnterCriticalSection(&m_pEngineState->csActive);
+        UserExperienceDeactivateEngine(&m_pEngineState->userExperience);
+
+        if (wzUrl && *wzUrl)
+        {
+            hr = StrAllocString(&m_pEngineState->update.sczUpdateSource, wzUrl, 0);
+            ExitOnFailure(hr, "Failed to set feed download URL.");
+        }
+        else // no URL provided means clear out the whole download source.
+        {
+            ReleaseNullStr(m_pEngineState->update.sczUpdateSource);
+        }
+
+    LExit:
+        UserExperienceActivateEngine(&m_pEngineState->userExperience, NULL);
+        ::LeaveCriticalSection(&m_pEngineState->csActive);
 
         return hr;
     }

--- a/src/burn/engine/detect.cpp
+++ b/src/burn/engine/detect.cpp
@@ -219,6 +219,7 @@ extern "C" HRESULT DetectUpdate(
     HRESULT hr = S_OK;
     int nResult = IDNOACTION;
     BOOL fBeginCalled = FALSE;
+    LPWSTR sczOriginalSource = NULL;
 
     // If no update source was specified, skip update detection.
     if (!pUpdate->sczUpdateSource || !*pUpdate->sczUpdateSource)
@@ -228,7 +229,10 @@ extern "C" HRESULT DetectUpdate(
 
     fBeginCalled = TRUE;
 
-    nResult = pUX->pUserExperience->OnDetectUpdateBegin(pUpdate->sczUpdateSource, IDNOACTION);
+    hr = StrAllocString(&sczOriginalSource, pUpdate->sczUpdateSource, 0);
+    ExitOnFailure(hr, "Failed to duplicate update feed source.");
+
+    nResult = pUX->pUserExperience->OnDetectUpdateBegin(sczOriginalSource, IDNOACTION);
     hr = UserExperienceInterpretResult(pUX, MB_OKCANCEL, nResult);
     ExitOnRootFailure(hr, "UX aborted detect update begin.");
 
@@ -243,6 +247,8 @@ extern "C" HRESULT DetectUpdate(
     }
 
 LExit:
+    ReleaseStr(sczOriginalSource);
+
     if (fBeginCalled)
     {
         pUX->pUserExperience->OnDetectUpdateComplete(hr, pUpdate->fUpdateAvailable ? pUpdate->sczUpdateSource : NULL);

--- a/src/burn/inc/IBootstrapperEngine.h
+++ b/src/burn/inc/IBootstrapperEngine.h
@@ -220,4 +220,10 @@ DECLARE_INTERFACE_IID_(IBootstrapperEngine, IUnknown, "6480D616-27A0-44D7-905B-8
         __in_z_opt LPCWSTR wzArguments,
         __in DWORD dwWaitForInputIdleTimeout
         ) = 0;
+
+    STDMETHOD(SetUpdateSource)(
+        __in_z LPCWSTR wzUrl,
+        __in_z_opt LPWSTR wzUser,
+        __in_z_opt LPWSTR wzPassword
+        ) = 0;
 };

--- a/src/ext/BalExtension/mba/core/Engine.cs
+++ b/src/ext/BalExtension/mba/core/Engine.cs
@@ -353,7 +353,7 @@ namespace Microsoft.Tools.WindowsInstallerXml.Bootstrapper
         /// <param name="hwndParent">The parent window of the elevation dialog (if the engine hasn't elevated yet).</param>
         /// <param name="approvedExeForElevationId">Id of the ApprovedExeForElevation element specified when the bundle was authored.</param>
         /// <param name="arguments">Optional arguments.</param>
-		/// <param name="waitForInputIdleTimeout">Timeout in milliseconds. When set to something other than zero, the engine will call WaitForInputIdle for the new process with this timeout before calling OnLaunchApprovedExeComplete.</param>
+        /// <param name="waitForInputIdleTimeout">Timeout in milliseconds. When set to something other than zero, the engine will call WaitForInputIdle for the new process with this timeout before calling OnLaunchApprovedExeComplete.</param>
         public void LaunchApprovedExe(IntPtr hwndParent, string approvedExeForElevationId, string arguments, int waitForInputIdleTimeout)
         {
             engine.LaunchApprovedExe(hwndParent, approvedExeForElevationId, arguments, waitForInputIdleTimeout);
@@ -413,6 +413,17 @@ namespace Microsoft.Tools.WindowsInstallerXml.Bootstrapper
         public void SetDownloadSource(string packageOrContainerId, string payloadId, string url, string user, string password)
         {
             this.engine.SetDownloadSource(packageOrContainerId, payloadId, url, user, password);
+        }
+
+        /// <summary>
+        /// Set the new download URL for the bundle update feed.
+        /// </summary>
+        /// <param name="url">The new url.</param>
+        /// <param name="user">The user name for proxy authentication.</param>
+        /// <param name="password">The password for proxy authentication.</param>
+        public void SetUpdateSource(string url, string user, string password)
+        {
+            this.engine.SetUpdateSource(url, user, password);
         }
 
         /// <summary>

--- a/src/ext/BalExtension/mba/core/IBootstrapperEngine.cs
+++ b/src/ext/BalExtension/mba/core/IBootstrapperEngine.cs
@@ -143,6 +143,12 @@ namespace Microsoft.Tools.WindowsInstallerXml.Bootstrapper
             [MarshalAs(UnmanagedType.LPWStr)] string wzArguments,
             [MarshalAs(UnmanagedType.U4)] int dwWaitForInputIdleTimeout
             );
+
+        void SetUpdateSource(
+            [MarshalAs(UnmanagedType.LPWStr)] string wzUrl,
+            [MarshalAs(UnmanagedType.LPWStr)] string wzUser,
+            [MarshalAs(UnmanagedType.LPWStr)] string wzPassword
+            );
     }
 
     /// <summary>


### PR DESCRIPTION
- Add IBootstrapperEngine::SetUpdateSource to let a BA update the feed URL.
- Pass OnDetectUpdateBegin a copy of the feed source, to preserve the value during the call in case it's updated by a call to IBootstrapperEngine::SetUpdateSource.