### PR TITLE
Fix lost focus post-elevation in Burn

### DIFF
--- a/src/burn/engine/pipe.cpp
+++ b/src/burn/engine/pipe.cpp
@@ -420,7 +420,7 @@ extern "C" HRESULT PipeLaunchChildProcess(
 
     // Since ShellExecuteEx doesn't support passing inherited handles, don't bother with CoreAppendFileHandleSelfToCommandLine.
     // We could fallback to using ::DuplicateHandle to inject the file handle later if necessary.
-    hr = ShelExec(wzExecutablePath, sczParameters, wzVerb, NULL, SW_HIDE, hwndParent, &hProcess);
+    hr = ShelExec(wzExecutablePath, sczParameters, wzVerb, NULL, SW_SHOWNA, hwndParent, &hProcess);
     ExitOnFailure(hr, "Failed to launch elevated child process: %ls", wzExecutablePath);
 
     pConnection->dwProcessId = ::GetProcessId(hProcess);

--- a/src/burn/engine/uithread.cpp
+++ b/src/burn/engine/uithread.cpp
@@ -134,8 +134,10 @@ static DWORD WINAPI ThreadProc(
     info.pUserExperience = &pEngineState->userExperience;
 
     // Create the window to handle reboots without activating it.
-    hWnd = ::CreateWindowExW(WS_EX_TOOLWINDOW, wc.lpszClassName, NULL, WS_POPUP | WS_VISIBLE, CW_USEDEFAULT, SW_SHOWNA, 0, 0, HWND_DESKTOP, NULL, pContext->hInstance, &info);
+    hWnd = ::CreateWindowExW(WS_EX_NOACTIVATE, wc.lpszClassName, NULL, WS_POPUP, 0, 0, 0, 0, HWND_DESKTOP, NULL, pContext->hInstance, &info);
     ExitOnNullWithLastError(hWnd, hr, "Failed to create window.");
+
+    ::ShowWindow(hWnd, SW_SHOWNA);
 
     // Persist the window handle and let the caller know we've initialized.
     pEngineState->hMessageWindow = hWnd;


### PR DESCRIPTION
When Burn launches the elevated process, it creates a window to handle
shutdown messages. Despite best efforts that invisible window was
getting focus. This fixes it so the shutdown messages window is "visible"
(0x0x0x0 sized window) for Restart Manager communication but never gets
focus.