### PR TITLE
Fix bundle layout after self-update

### DIFF
--- a/src/burn/engine/apply.cpp
+++ b/src/burn/engine/apply.cpp
@@ -57,6 +57,7 @@ static DWORD64 GetCacheActionSuccessProgress(
     __in BURN_CACHE_ACTION* pCacheAction
     );
 static HRESULT LayoutBundle(
+    __in HANDLE hSourceEngineFile,
     __in BURN_USER_EXPERIENCE* pUX,
     __in BURN_VARIABLES* pVariables,
     __in HANDLE hPipe,
@@ -101,6 +102,7 @@ static HRESULT PromptForSource(
     );
 static HRESULT CopyPayload(
     __in BURN_CACHE_ACQUIRE_PROGRESS_CONTEXT* pProgress,
+    __in HANDLE hSourceFile,
     __in_z LPCWSTR wzSourcePath,
     __in_z LPCWSTR wzDestinationPath
     );
@@ -476,7 +478,7 @@ extern "C" HRESULT ApplyCache(
                 break;
 
             case BURN_CACHE_ACTION_TYPE_LAYOUT_BUNDLE:
-                hr = LayoutBundle(pUX, pVariables, hPipe, pCacheAction->bundleLayout.sczExecutableName, pCacheAction->bundleLayout.sczLayoutDirectory, pCacheAction->bundleLayout.sczUnverifiedPath, qwSuccessfulCachedProgress, pPlan->qwCacheSizeTotal);
+                hr = LayoutBundle(hSourceEngineFile, pUX, pVariables, hPipe, pCacheAction->bundleLayout.sczExecutableName, pCacheAction->bundleLayout.sczLayoutDirectory, pCacheAction->bundleLayout.sczUnverifiedPath, qwSuccessfulCachedProgress, pPlan->qwCacheSizeTotal);
                 if (SUCCEEDED(hr))
                 {
                     qwSuccessfulCachedProgress += pCacheAction->bundleLayout.qwBundleSize;
@@ -929,6 +931,7 @@ static DWORD64 GetCacheActionSuccessProgress(
 }
 
 static HRESULT LayoutBundle(
+    __in HANDLE hSourceEngineFile,
     __in BURN_USER_EXPERIENCE* pUX,
     __in BURN_VARIABLES* pVariables,
     __in HANDLE hPipe,
@@ -965,7 +968,7 @@ static HRESULT LayoutBundle(
     hr = PathCompare(sczBundlePath, sczDestinationPath, &nEquivalentPaths);
     ExitOnFailure(hr, "Failed to determine if layout bundle path was equivalent with current process path.");
 
-    if (CSTR_EQUAL == nEquivalentPaths)
+    if (CSTR_EQUAL == nEquivalentPaths && FileExistsEx(sczDestinationPath, NULL))
     {
         ExitFunction1(hr = S_OK);
     }
@@ -987,7 +990,7 @@ static HRESULT LayoutBundle(
             hr = UserExperienceInterpretExecuteResult(pUX, FALSE, MB_OKCANCEL, nResult);
             ExitOnRootFailure(hr, "BA aborted cache acquire begin.");
 
-            hr = CopyPayload(&progress, sczBundlePath, wzUnverifiedPath);
+            hr = CopyPayload(&progress, hSourceEngineFile, sczBundlePath, wzUnverifiedPath);
             // Error handling happens after sending complete message to BA.
 
             nResult = pUX->pUserExperience->OnCacheAcquireComplete(NULL, NULL, hr, IDNOACTION);
@@ -1123,7 +1126,7 @@ static HRESULT AcquireContainerOrPayload(
             hr = UserExperienceInterpretExecuteResult(pUX, FALSE, MB_OKCANCEL, nResult);
             ExitOnRootFailure(hr, "BA aborted cache acquire begin.");
 
-            hr = CopyPayload(&progress, sczSourceFullPath, wzDestinationPath);
+            hr = CopyPayload(&progress, INVALID_HANDLE_VALUE, sczSourceFullPath, wzDestinationPath);
             // Error handling happens after sending complete message to BA.
 
             // We successfully copied from a source location, set that as the last used source.
@@ -1313,6 +1316,7 @@ static HRESULT PromptForSource(
 
 static HRESULT CopyPayload(
     __in BURN_CACHE_ACQUIRE_PROGRESS_CONTEXT* pProgress,
+    __in HANDLE hSourceFile,
     __in_z LPCWSTR wzSourcePath,
     __in_z LPCWSTR wzDestinationPath
     )
@@ -1321,6 +1325,8 @@ static HRESULT CopyPayload(
     DWORD dwFileAttributes = 0;
     LPCWSTR wzPackageOrContainerId = pProgress->pContainer ? pProgress->pContainer->sczId : pProgress->pPackage ? pProgress->pPackage->sczId : L"";
     LPCWSTR wzPayloadId = pProgress->pPayload ? pProgress->pPayload->sczKey : L"";
+    HANDLE hDestinationFile = INVALID_HANDLE_VALUE;
+    HANDLE hSourceOpenedFile = INVALID_HANDLE_VALUE;
 
     DWORD dwLogId = pProgress->pContainer ? (pProgress->pPayload ? MSG_ACQUIRE_CONTAINER_PAYLOAD : MSG_ACQUIRE_CONTAINER) : pProgress->pPackage ? MSG_ACQUIRE_PACKAGE_PAYLOAD : MSG_ACQUIRE_BUNDLE_PAYLOAD;
     LogId(REPORT_STANDARD, dwLogId, wzPackageOrContainerId, wzPayloadId, "copy", wzSourcePath);
@@ -1338,7 +1344,30 @@ static HRESULT CopyPayload(
         }
     }
 
-    if (!::CopyFileExW(wzSourcePath, wzDestinationPath, CacheProgressRoutine, pProgress, &pProgress->fCancel, 0))
+    if (INVALID_HANDLE_VALUE == hSourceFile)
+    {
+        hSourceOpenedFile = ::CreateFileW(wzSourcePath, GENERIC_READ, FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE, NULL, OPEN_EXISTING, FILE_ATTRIBUTE_NORMAL | FILE_FLAG_SEQUENTIAL_SCAN, NULL);
+        if (INVALID_HANDLE_VALUE == hSourceOpenedFile)
+        {
+            ExitWithLastError(hr, "Failed to open source file to copy payload from: '%ls' to: %ls.", wzSourcePath, wzDestinationPath);
+        }
+
+        hSourceFile = hSourceOpenedFile;
+    }
+    else
+    {
+        hr = FileSetPointer(hSourceFile, 0, NULL, FILE_BEGIN);
+        ExitOnRootFailure(hr, "Failed to read from start of source file to copy payload from: '%ls' to: %ls.", wzSourcePath, wzDestinationPath);
+    }
+
+    hDestinationFile = ::CreateFileW(wzDestinationPath, GENERIC_WRITE, FILE_SHARE_READ | FILE_SHARE_WRITE | FILE_SHARE_DELETE, NULL, CREATE_ALWAYS, FILE_ATTRIBUTE_NORMAL | FILE_FLAG_SEQUENTIAL_SCAN, NULL);
+    if (INVALID_HANDLE_VALUE == hDestinationFile)
+    {
+        ExitWithLastError(hr, "Failed to open destination file to copy payload from: '%ls' to: %ls.", wzSourcePath, wzDestinationPath);
+    }
+
+    hr = FileCopyUsingHandlesWithProgress(hSourceFile, hDestinationFile, 0, CacheProgressRoutine, pProgress, &pProgress->fCancel, NULL);
+    if (FAILED(hr))
     {
         if (pProgress->fCancel)
         {
@@ -1347,11 +1376,14 @@ static HRESULT CopyPayload(
         }
         else
         {
-            ExitWithLastError2(hr, "Failed attempt to copy payload from: '%ls' to: %ls.", wzSourcePath, wzDestinationPath);
+            ExitOnRootFailure(hr, "Failed attempt to copy payload from: '%ls' to: %ls.", wzSourcePath, wzDestinationPath);
         }
     }
 
 LExit:
+    ReleaseFileHandle(hDestinationFile);
+    ReleaseFileHandle(hSourceOpenedFile);
+
     return hr;
 }
 

--- a/src/libs/dutil/fileutil.cpp
+++ b/src/libs/dutil/fileutil.cpp
@@ -1059,6 +1059,134 @@ LExit:
 
 
 /*******************************************************************
+ FileCopyUsingHandlesWithProgress
+
+*******************************************************************/
+extern "C" HRESULT DAPI FileCopyUsingHandlesWithProgress(
+    __in HANDLE hSource,
+    __in HANDLE hTarget,
+    __in DWORD64 cbCopy,
+    __in_opt LPPROGRESS_ROUTINE lpProgressRoutine,
+    __in_opt LPVOID lpData,
+    __in_opt LPBOOL pbCancel,
+    __out_opt DWORD64* pcbCopied
+)
+{
+    HRESULT hr = S_OK;
+    BOOL fStop = FALSE;
+    BOOL fCanceled = FALSE;
+    DWORD64 cbTotalCopied = 0;
+    BYTE rgbData[64 * 1024];
+    DWORD cbRead = 0;
+
+    LARGE_INTEGER liSourceSize = { };
+    LARGE_INTEGER liTotalCopied = { };
+    LARGE_INTEGER liZero = { };
+    DWORD dwResult = 0;
+
+    hr = FileSizeByHandle(hSource, &liSourceSize.QuadPart);
+    ExitOnFailure(hr, "Failed to get size of source.");
+
+    if (0 < cbCopy && cbCopy < (DWORD64)liSourceSize.QuadPart)
+    {
+        liSourceSize.QuadPart = cbCopy;
+    }
+
+    dwResult = lpProgressRoutine(liSourceSize, liTotalCopied, liZero, liZero, 0, CALLBACK_STREAM_SWITCH, hSource, hTarget, lpData);
+    switch (dwResult)
+    {
+    case PROGRESS_CONTINUE:
+        break;
+
+    case PROGRESS_CANCEL:
+        fCanceled = TRUE;
+        fStop = TRUE;
+        break;
+
+    case PROGRESS_STOP:
+        fStop = TRUE;
+        break;
+
+    case PROGRESS_QUIET:
+        lpProgressRoutine = NULL;
+        break;
+    }
+
+    // Set size of the target file.
+    ::SetFilePointerEx(hTarget, liSourceSize, NULL, FILE_BEGIN);
+
+    if (!::SetEndOfFile(hTarget))
+    {
+        ExitWithLastError(hr, "Failed to set end of target file.");
+    }
+
+    if (!::SetFilePointerEx(hTarget, liZero, NULL, FILE_BEGIN))
+    {
+        ExitWithLastError(hr, "Failed to reset target file pointer.");
+    }
+
+    // Copy with progress.
+    while (!fStop && (0 == cbCopy || cbTotalCopied < cbCopy))
+    {
+        cbRead = static_cast<DWORD>((0 == cbCopy) ? countof(rgbData) : min(countof(rgbData), cbCopy - cbTotalCopied));
+        if (!::ReadFile(hSource, rgbData, cbRead, &cbRead, NULL))
+        {
+            ExitWithLastError(hr, "Failed to read from source.");
+        }
+
+        if (cbRead)
+        {
+            hr = FileWriteHandle(hTarget, rgbData, cbRead);
+            ExitOnFailure(hr, "Failed to write to target.");
+
+            cbTotalCopied += cbRead;
+
+            if (lpProgressRoutine)
+            {
+                liTotalCopied.QuadPart = cbTotalCopied;
+                dwResult = lpProgressRoutine(liSourceSize, liTotalCopied, liZero, liZero, 0, CALLBACK_CHUNK_FINISHED, hSource, hTarget, lpData);
+                switch (dwResult)
+                {
+                case PROGRESS_CONTINUE:
+                    break;
+
+                case PROGRESS_CANCEL:
+                    fCanceled = TRUE;
+                    fStop = TRUE;
+                    break;
+
+                case PROGRESS_STOP:
+                    fStop = TRUE;
+                    break;
+
+                case PROGRESS_QUIET:
+                    lpProgressRoutine = NULL;
+                    break;
+                }
+            }
+        }
+        else
+        {
+            fStop = TRUE;
+        }
+    }
+
+LExit:
+    if (pbCancel)
+    {
+        *pbCancel = fCanceled;
+    }
+
+    if (pcbCopied)
+    {
+        *pcbCopied = cbTotalCopied;
+    }
+
+    return hr;
+}
+
+
+/*******************************************************************
  FileEnsureCopy
 
 *******************************************************************/

--- a/src/libs/dutil/inc/fileutil.h
+++ b/src/libs/dutil/inc/fileutil.h
@@ -132,6 +132,15 @@ HRESULT DAPI FileCopyUsingHandles(
     __in DWORD64 cbCopy,
     __out_opt DWORD64* pcbCopied
     );
+HRESULT DAPI FileCopyUsingHandlesWithProgress(
+    __in HANDLE hSource,
+    __in HANDLE hTarget,
+    __in DWORD64 cbCopy,
+    __in_opt LPPROGRESS_ROUTINE lpProgressRoutine,
+    __in_opt LPVOID lpData,
+    __in_opt LPBOOL pbCancel,
+    __out_opt DWORD64* pcbCopied
+    );
 HRESULT DAPI FileEnsureCopy(
     __in_z LPCWSTR wzSource,
     __in_z LPCWSTR wzTarget,


### PR DESCRIPTION
During layout Burn will now use the handle to source engine to copy the
bundle executable since the file may have been deleted when run as part
of a self-update.
